### PR TITLE
[根目录][优化]翻译小组分工表格式

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -5,137 +5,137 @@
 ```
 .
 ├── concepts
-│   ├── api  													唐柠
-│   ├── architecture 									唐柠
-│   ├── bluetooth 										唐柠
+│   ├── api ----------------------------| 唐柠
+│   ├── architecture -------------------| 唐柠
+│   ├── bluetooth ----------------------| 唐柠
 │   │   └── images
-│   ├── booting                                         Roy
+│   ├── booting ------------------------| Roy
 │   │   └── images
-│   ├── build_system									Whyto
-│   ├── components
-│   │   ├── v1
-│   │   └── v2
-│   ├── diagnostics
-│   │   ├── inspect
-│   │   ├── lifecycle_events
-│   │   └── logs
-│   ├── drivers
-│   │   ├── device_driver_model
-│   │   ├── driver_architectures
-│   │   └── driver_development
-│   ├── emulator
-│   ├── fidl
+│   ├── build_system -------------------| Whyto
+│   ├── components ---------------------|
+│   │   ├── v1                          |
+│   │   └── v2                          |
+│   ├── diagnostics --------------------|
+│   │   ├── inspect                     |
+│   │   ├── lifecycle_events            |
+│   │   └── logs                        |
+│   ├── drivers ------------------------|
+│   │   ├── device_driver_model         |
+│   │   ├── driver_architectures        |
+│   │   └── driver_development          |
+│   ├── emulator -----------------------|
+│   ├── fidl ---------------------------|
+│   │   └── images                      |
+│   ├── filesystems --------------------|
+│   │   └── images                      |
+│   ├── graphics -----------------------|
+│   │   ├── escher                      |
+│   │   ├── magma                       |
+│   │   ├── scenic                      |
+│   │   └── sysmem                      |
+│   ├── internationalization -----------|
+│   ├── kernel -------------------------|
+│   │   └── images                      |
+│   ├── media --------------------------|
+│   ├── modular ------------------------|
+│   │   └── guide                       |
+│   ├── monitoring ---------------------|
+│   ├── networking ---------------------|
+│   ├── packages -----------------------|
 │   │   └── images
-│   ├── filesystems
+│   ├── prebuilt_packages --------------|
+│   ├── principles ---------------------|
+│   ├── process ------------------------|
+│   ├── session ------------------------|
 │   │   └── images
-│   ├── graphics
-│   │   ├── escher
-│   │   ├── magma
-│   │   ├── scenic
-│   │   └── sysmem
-│   ├── internationalization
-│   ├── kernel
-│   │   └── images
-│   ├── media
-│   ├── modular
-│   │   └── guide
-│   ├── monitoring
-│   ├── networking
-│   ├── packages
-│   │   └── images
-│   ├── prebuilt_packages
-│   ├── principles
-│   ├── process
-│   ├── session
-│   │   └── images
-│   ├── settings
-│   │   └── policy
-│   ├── source_code
-│   ├── system
-│   │   ├── abi
-│   │   └── jitterentropy
-│   ├── testing
-│   │   └── v2
-│   ├── time
-│   │   └── utc
-│   ├── tracing
-│   │   └── images
-│   └── usb                                             Wilde Luo
-├── contribute
-│   ├── community													yang-lile
-│   │   └── images
-│   ├── contributing-to-fidl
-│   ├── docs
-│   ├── governance
-│   │   ├── apis
-│   │   ├── areas
-│   │   ├── policy
-│   │   └── rfcs
-│   ├── open_projects
-│   │   ├── build
-│   │   ├── cpp
-│   │   ├── graduated
-│   │   ├── logging
-│   │   └── srcs
-│   └── roadmap
-│       ├── 2020
-│       └── 2021
-├── development
-│   ├── benchmarking
-│   ├── build
-│   ├── components
-│   │   ├── v1
-│   │   └── v2
-│   ├── debugger
-│   ├── debugging
-│   ├── diagnostics
-│   │   ├── inspect
-│   │   ├── logs
-│   │   └── triage
-│   ├── drivers
-│   │   ├── best_practices
-│   │   ├── developer_guide
-│   │   ├── diagnostics
-│   │   ├── driver_guides
-│   │   ├── testing
-│   │   └── tutorials
-│   ├── editors
-│   ├── error_codes
-│   ├── hardware
-│   ├── idk
-│   │   ├── documentation
-│   │   └── gn
-│   ├── internationalization
-│   │   ├── fonts
-│   │   └── localization
-│   ├── kernel														Dongchan
+│   ├── settings -----------------------|
+│   │   └── policy                      |
+│   ├── source_code --------------------|
+│   ├── system -------------------—-----|
+│   │   ├── abi                         |
+│   │   └── jitterentropy               |
+│   ├── testing ------------------------|
+│   │   └── v2                          |
+│   ├── time ---------------------------|
+│   │   └── utc                         |
+│   ├── tracing ------------------------|
+│   │   └── images                      |
+│   └── usb ----------------------------| Wilde Luo
+├── contribute                          |
+│   ├── community-----------------------| yang-lile
+│   │   └── images                      |
+│   ├── contributing-to-fidl -----------|
+│   ├── docs ---------------------------|
+│   ├── governance ---------------------|
+│   │   ├── apis                        |
+│   │   ├── areas                       |
+│   │   ├── policy                      |
+│   │   └── rfcs                        |
+│   ├── open_projects ------------------|
+│   │   ├── build                       |
+│   │   ├── cpp                         |
+│   │   ├── graduated                   |
+│   │   ├── logging                     |
+│   │   └── srcs                        |
+│   └── roadmap ------------------------|
+│       ├── 2020                        |
+│       └── 2021                        |
+├── development                         |
+│   ├── benchmarking -------------------|
+│   ├── build --------------------------|
+│   ├── components ---------------------|
+│   │   ├── v1                          |
+│   │   └── v2                          |
+│   ├── debugger -----------------------|
+│   ├── debugging ----------------------|
+│   ├── diagnostics --------------------|
+│   │   ├── inspect                     |
+│   │   ├── logs                        |
+│   │   └── triage                      |
+│   ├── drivers ------------------------|
+│   │   ├── best_practices              |
+│   │   ├── developer_guide             |
+│   │   ├── diagnostics                 |
+│   │   ├── driver_guides               |
+│   │   ├── testing                     |
+│   │   └── tutorials                   |
+│   ├── editors ------------------------|
+│   ├── error_codes --------------------|
+│   ├── hardware -----------------------|
+│   ├── idk ----------------------------|
+│   │   ├── documentation               |
+│   │   └── gn                          |
+│   ├── internationalization -----------|
+│   │   ├── fonts                       |
+│   │   └── localization                |
+│   ├── kernel -------------------------| Dongchan
 │   │   ├── memory										
 │   │   └── threads
-│   ├── languages                          yangxuan74
-│   │   ├── c-cpp
-│   │   ├── dart
-│   │   ├── fidl
-│   │   ├── go
-│   │   ├── new
-│   │   ├── python
-│   │   └── rust
-│   ├── monitoring
-│   │   ├── devtools
-│   │   └── fidlcat
-│   ├── prebuilt_packages
-│   ├── run
-│   ├── sessions
-│   ├── settings
-│   ├── source_code
-│   ├── testing
-│   │   └── fuzzing
-│   ├── tools
-│   │   └── ffx
-│   └── tracing
-│       ├── advanced
-│       └── tutorial
-├── gen
-├── get-started 												Sylsd
+│   ├── languages ----------------------| yangxuan74
+│   │   ├── c-cpp                       |
+│   │   ├── dart                        |
+│   │   ├── fidl                        |
+│   │   ├── go                          |
+│   │   ├── new                         |
+│   │   ├── python                      |
+│   │   └── rust                        |
+│   ├── monitoring ---------------------|
+│   │   ├── devtools                    |
+│   │   └── fidlcat                     |
+│   ├── prebuilt_packages --------------|
+│   ├── run ----------------------------|
+│   ├── sessions -----------------------|
+│   ├── settings -----------------------|
+│   ├── source_code --------------------|
+│   ├── testing ------------------------|
+│   │   └── fuzzing                     |
+│   ├── tools --------------------------|
+│   │   └── ffx                         |
+│   └── tracing  -----------------------|
+│       ├── advanced                    |
+│       └── tutorial                    |
+├── gen --------------------------------|
+├── get-started ------------------------| Sylsd
 ├── images
 │   ├── benchmarking
 │   ├── developing_on_nuc
@@ -144,20 +144,20 @@
 │   ├── testing
 │   └── zircon
 │       └── ddk
-└── reference
-    ├── diagnostics
-    │   ├── consumers
-    │   ├── inspect
-    │   └── logs
-    ├── fidl
-    │   ├── bindings
-    │   └── language
-    ├── kernel
-    ├── kernel_objects
-    ├── syscalls
-    ├── tools
-    │   └── sdk
-    └── tracing
+└── reference --------------------------|
+    ├── diagnostics --------------------|
+    │   ├── consumers                   |
+    │   ├── inspect                     |
+    │   └── logs                        |
+    ├── fidl ---------------------------|
+    │   ├── bindings                    |
+    │   └── language                    |
+    ├── kernel -------------------------|
+    ├── kernel_objects -----------------|
+    ├── syscalls -----------------------|
+    ├── tools --------------------------|
+    │   └── sdk                         |
+    └── tracing ------------------------|
         └── images
 ```
 


### PR DESCRIPTION
添加辅助线，避免空格过多导致认领者名称超出Github显示边界，导致其他认领者不方便查看已被领取的目录。