### PR TITLE
modify link inside development languages README.md

### DIFF
--- a/development/languages/README.md
+++ b/development/languages/README.md
@@ -1,10 +1,10 @@
 # Language usage in Fuchsia
 
-* [Supporting new languages](/docs/development/languages/new/structure.md)
-* [Linting and Formatting](/docs/development/languages/lint_and_format.md)
-* [C/C++](/docs/development/languages/c-cpp)
-* [Dart](/docs/development/languages/dart)
-* [FIDL](/docs/development/languages/fidl)
-* [Go](/docs/development/languages/go)
-* [Python](/docs/development/languages/python)
-* [Rust](/docs/development/languages/rust)
+* [Supporting new languages](/development/languages/new/structure.md)
+* [Linting and Formatting](/development/languages/lint_and_format.md)
+* [C/C++](/development/languages/c-cpp)
+* [Dart](/development/languages/dart)
+* [FIDL](/development/languages/fidl)
+* [Go](/development/languages/go)
+* [Python](/development/languages/python)
+* [Rust](/development/languages/rust)


### PR DESCRIPTION
When I click on the links in development languages README.md, Page not found appears.

So I modified the links .